### PR TITLE
fix `var`/import errors and warnings

### DIFF
--- a/source/Parser.zig
+++ b/source/Parser.zig
@@ -7,13 +7,13 @@
 //! It handles the execution and the passing of messages between the two objects.
 
 const rem = @import("../rem.zig");
-const Dom = @import("./Dom.zig");
+const Dom = @import("Dom.zig");
 const Document = Dom.Document;
 const Element = Dom.Element;
 
-const Token = @import("./token.zig").Token;
-const Tokenizer = @import("./Tokenizer.zig");
-const tree_construction = @import("./tree_construction.zig");
+const Token = @import("token.zig").Token;
+const Tokenizer = @import("Tokenizer.zig");
+const tree_construction = @import("tree_construction.zig");
 const TreeConstructor = tree_construction.TreeConstructor;
 
 const std = @import("std");

--- a/source/Tokenizer.zig
+++ b/source/Tokenizer.zig
@@ -7,10 +7,10 @@
 
 const Tokenizer = @This();
 const rem = @import("../rem.zig");
-const named_characters = @import("./named_characters.zig");
-const Token = @import("./token.zig").Token;
+const named_characters = @import("named_characters.zig");
+const Token = @import("token.zig").Token;
 const Attributes = Token.StartTag.Attributes;
-const Parser = @import("./Parser.zig");
+const Parser = @import("Parser.zig");
 const ParseError = Parser.ParseError;
 
 const std = @import("std");

--- a/source/tree_construction.zig
+++ b/source/tree_construction.zig
@@ -11,12 +11,12 @@ const ComptimeStringMap = std.ComptimeStringMap;
 const StringHashMapUnmanaged = std.StringHashMapUnmanaged;
 
 const rem = @import("../rem.zig");
-const Token = @import("./token.zig").Token;
-const Tokenizer = @import("./Tokenizer.zig");
-const Parser = @import("./Parser.zig");
+const Token = @import("token.zig").Token;
+const Tokenizer = @import("Tokenizer.zig");
+const Parser = @import("Parser.zig");
 const ParseError = Parser.ParseError;
 
-const Dom = @import("./Dom.zig");
+const Dom = @import("Dom.zig");
 const Document = Dom.Document;
 const Element = Dom.Element;
 const ElementType = Dom.ElementType;
@@ -2929,7 +2929,7 @@ fn appropriateNodeInsertionLocationWithTarget(c: *TreeConstructor, target: *Elem
 
         // Steps 2.1 and 2.2
         while (index > 0) : (index -= 1) {
-            var node = c.open_elements.items[index - 1];
+            const node = c.open_elements.items[index - 1];
             if (node.element_type == .html_template) {
                 last_template = node;
                 if (last_table != null) break;

--- a/test/html5lib-test-tokenizer.zig
+++ b/test/html5lib-test-tokenizer.zig
@@ -121,12 +121,12 @@ fn runTestFile(file_path: []const u8) !void {
     defer arena.deinit();
     const arena_allocator = arena.allocator();
 
-    var contents = try std.fs.cwd().readFileAlloc(arena_allocator, file_path, std.math.maxInt(usize));
+    const contents = try std.fs.cwd().readFileAlloc(arena_allocator, file_path, std.math.maxInt(usize));
     defer arena_allocator.free(contents);
     var tree = try std.json.parseFromSlice(std.json.Value, arena_allocator, contents, .{});
     defer tree.deinit();
 
-    var tests = tree.value.object.get("tests").?.array;
+    const tests = tree.value.object.get("tests").?.array;
     var progress = Progress{};
     const prog_root = progress.start("", tests.items.len);
 

--- a/test/html5lib-test-tree-construction.zig
+++ b/test/html5lib-test-tree-construction.zig
@@ -310,7 +310,7 @@ fn createTest(test_string: *[]const u8, allocator: Allocator) !Test {
     //var document: []const u8 = lines.rest();
     //std.debug.print("#document\n{s}\n", .{document});
 
-    var expected = parseDom(&lines, context_element_type, allocator) catch |err| switch (err) {
+    const expected = parseDom(&lines, context_element_type, allocator) catch |err| switch (err) {
         error.DomException => unreachable,
         else => |e| return e,
     };


### PR DESCRIPTION
Zig now emits errors for `var` that can be `const`, and warnings for import paths that contain unneccessary bits. Fixed those.