### PR TITLE
Update to Zig 0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone --recursive --config core.autocrlf=false https://github.com/chadwain/r
 zig fetch --save https://github.com/chadwain/rem/archive/refs/heads/master.tar.gz
 ```
 
-There are no dependencies other than a Zig compiler. Note that this library is only compatible with Zig version 0.11.0 or newer.
+There are no dependencies other than a Zig compiler. Note that this library is only compatible with Zig version 0.15.1 or newer.
 
 ## Use the code
 Here's an example of using the parser. You can see the output of this program by running `zig build example`.
@@ -68,9 +68,12 @@ pub fn main() !void {
     std.debug.assert(errors.len == 0);
 
     // We can now print the resulting Document to the console.
-    const stdout = std.io.getStdOut().writer();
+    var buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&buffer);
+    const stdout = &stdout_writer.interface;
     const document = parser.getDocument();
     try rem.util.printDocument(stdout, document, &dom, allocator);
+    try stdout.flush();
 }
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -15,11 +15,17 @@ pub fn build(b: *std.Build) void {
     });
     const named_character_references_mod = named_character_references.module("named_character_references");
 
-    const rem_lib = b.addStaticLibrary(.{
-        .name = "rem",
+    const rem_module = b.addModule("rem", .{
         .root_source_file = b.path("rem.zig"),
         .target = target,
         .optimize = optimize,
+    });
+    rem_module.addImport("named_character_references", named_character_references_mod);
+
+    const rem_lib = b.addLibrary(.{
+        .name = "rem",
+        .root_module = rem_module,
+        .linkage = .static,
     });
     rem_lib.root_module.addImport("named_character_references", named_character_references_mod);
     b.installArtifact(rem_lib);
@@ -27,9 +33,7 @@ pub fn build(b: *std.Build) void {
     {
         const rem_unit_tests = b.addTest(.{
             .name = "rem-unit-tests",
-            .root_source_file = b.path("rem.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = rem_module,
         });
         rem_unit_tests.root_module.addImport("named_character_references", named_character_references_mod);
         b.installArtifact(rem_unit_tests);
@@ -41,15 +45,15 @@ pub fn build(b: *std.Build) void {
         rem_unit_tests_run_step.dependOn(&rem_unit_tests_run.step);
     }
 
-    const rem_module = b.addModule("rem", .{ .root_source_file = b.path("rem.zig") });
-    rem_module.addImport("named_character_references", named_character_references_mod);
-
     {
-        const html5lib_tokenizer_tests = b.addTest(.{
-            .name = "html5lib-tokenizer-tests",
+        const html5lib_tokenizer_module = b.createModule(.{
             .root_source_file = b.path("test/html5lib-test-tokenizer.zig"),
             .target = target,
             .optimize = optimize,
+        });
+        const html5lib_tokenizer_tests = b.addTest(.{
+            .name = "html5lib-tokenizer-tests",
+            .root_module = html5lib_tokenizer_module,
         });
         html5lib_tokenizer_tests.root_module.addImport("rem", rem_module);
         b.installArtifact(html5lib_tokenizer_tests);
@@ -65,11 +69,14 @@ pub fn build(b: *std.Build) void {
     }
 
     {
-        const html5lib_tree_construction_tests = b.addTest(.{
-            .name = "html5lib-tree-construction-tests",
+        const html5lib_tree_construction_module = b.createModule(.{
             .root_source_file = b.path("test/html5lib-test-tree-construction.zig"),
             .target = target,
             .optimize = optimize,
+        });
+        const html5lib_tree_construction_tests = b.addTest(.{
+            .name = "html5lib-tree-construction-tests",
+            .root_module = html5lib_tree_construction_module,
         });
         html5lib_tree_construction_tests.root_module.addImport("rem", rem_module);
         b.installArtifact(html5lib_tree_construction_tests);
@@ -82,11 +89,14 @@ pub fn build(b: *std.Build) void {
     }
 
     {
-        const example = b.addExecutable(.{
-            .name = "example",
+        const example_module = b.createModule(.{
             .root_source_file = b.path("./example.zig"),
             .target = target,
             .optimize = optimize,
+        });
+        const example = b.addExecutable(.{
+            .name = "example",
+            .root_module = example_module,
         });
         example.root_module.addImport("rem", rem_module);
         b.installArtifact(example);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,7 +7,7 @@
             .hash = "named_character_references-0.1.0-dTxagvKDBQBIUZJON6GwaPomhxlrp77NJS_ekr77AFdN",
         },
     },
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.1",
     .fingerprint = 0x83bde72b9431762b,
     .paths = .{
         "build.zig",

--- a/example.zig
+++ b/example.zig
@@ -33,7 +33,10 @@ pub fn main() !void {
     std.debug.assert(errors.len == 0);
 
     // We can now print the resulting Document to the console.
-    const stdout = std.io.getStdOut().writer();
+    var buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&buffer);
+    const stdout = &stdout_writer.interface;
     const document = parser.getDocument();
     try rem.util.printDocument(stdout, document, &dom, allocator);
+    try stdout.flush();
 }

--- a/source/Dom.zig
+++ b/source/Dom.zig
@@ -26,7 +26,7 @@ pub const mutation = @import("dom/mutation.zig");
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
-const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const ArrayList = std.ArrayList;
 const StaticStringMap = std.StaticStringMap;
 const MultiArrayList = std.MultiArrayList;
 const AutoHashMapUnmanaged = std.AutoHashMapUnmanaged;
@@ -40,10 +40,10 @@ local_names: AutoHashMapUnmanaged(*const Element, []const u8) = .{},
 /// This does not take precedence if finding if an element is an HTML integration point could be done by other means.
 html_integration_points: AutoHashMapUnmanaged(*const Element, void) = .{},
 
-all_documents: ArrayListUnmanaged(*Document) = .{},
-all_elements: ArrayListUnmanaged(*Element) = .{},
-all_cdatas: ArrayListUnmanaged(*CharacterData) = .{},
-all_doctypes: ArrayListUnmanaged(*DocumentType) = .{},
+all_documents: ArrayList(*Document) = .empty,
+all_elements: ArrayList(*Element) = .empty,
+all_cdatas: ArrayList(*CharacterData) = .empty,
+all_doctypes: ArrayList(*DocumentType) = .empty,
 
 pub fn deinit(self: *Dom) void {
     for (self.all_elements.items) |item| {

--- a/source/Parser.zig
+++ b/source/Parser.zig
@@ -19,7 +19,7 @@ const TreeConstructor = tree_construction.TreeConstructor;
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
-const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const ArrayList = std.ArrayList;
 
 input_stream: InputStream,
 tokenizer_initial_state: Tokenizer.State,
@@ -104,7 +104,7 @@ pub const OnError = enum {
 pub const ErrorHandler = union(OnError) {
     ignore,
     abort: ?ParseError,
-    report: ArrayListUnmanaged(ParseError),
+    report: ArrayList(ParseError),
 
     fn init(on_error: OnError) ErrorHandler {
         return switch (on_error) {
@@ -299,7 +299,7 @@ pub fn initTokenizerOnly(
     };
 }
 
-pub fn runTokenizerOnly(self: *Self, token_sink: *std.ArrayList(Token)) !void {
+pub fn runTokenizerOnly(self: *Self, allocator: Allocator, token_sink: *ArrayList(Token)) !void {
     var tokenizer = Tokenizer.init(self, self.tokenizer_initial_state, self.tokenizer_initial_last_start_tag);
     defer tokenizer.deinit();
     while (!tokenizer.eof) {
@@ -312,7 +312,7 @@ pub fn runTokenizerOnly(self: *Self, token_sink: *std.ArrayList(Token)) !void {
         };
 
         const old_len = token_sink.items.len;
-        try token_sink.resize(old_len + tokenizer.tokens.items.len);
+        try token_sink.resize(allocator, old_len + tokenizer.tokens.items.len);
         tokenizer.moveTokens(token_sink.items[old_len..]);
     }
 }

--- a/source/dom/node.zig
+++ b/source/dom/node.zig
@@ -7,14 +7,14 @@ const Dom = @import("../Dom.zig");
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const ArrayList = std.ArrayList;
 const StaticStringMap = std.StaticStringMap;
 const MultiArrayList = std.MultiArrayList;
 
 pub const Document = struct {
     doctype: ?*DocumentType = null,
     element: ?*Element = null,
-    cdata: ArrayListUnmanaged(*CharacterData) = .{},
+    cdata: ArrayList(*CharacterData) = .empty,
     cdata_endpoints: [3]Endpoints = .{Endpoints{ .begin = 0, .end = 0 }} ** 3,
     cdata_current_endpoint: u2 = 0,
     quirks_mode: QuirksMode = .no_quirks,
@@ -59,7 +59,7 @@ pub const DocumentFormatter = struct {
             element: *const Element,
             cdata: *const CharacterData,
         };
-        var node_stack = ArrayListUnmanaged(struct { node: ConstElementOrCharacterData, depth: usize }){};
+        var node_stack: ArrayList(struct { node: ConstElementOrCharacterData, depth: usize }) = .empty;
         defer node_stack.deinit(self.allocator);
 
         if (self.document.element) |document_element| {
@@ -764,7 +764,7 @@ pub const Element = struct {
     element_type: ElementType,
     parent: ?ParentNode,
     attributes: ElementAttributes,
-    children: ArrayListUnmanaged(ElementOrCharacterData),
+    children: ArrayList(ElementOrCharacterData),
 
     pub fn deinit(self: *Element, allocator: Allocator) void {
         const attr_slice = self.attributes.slice();
@@ -842,7 +842,7 @@ pub const CharacterDataInterface = enum {
 };
 
 pub const CharacterData = struct {
-    data: ArrayListUnmanaged(u8) = .{},
+    data: ArrayList(u8) = .empty,
     interface: CharacterDataInterface,
 
     pub fn init(allocator: Allocator, data: []const u8, interface: CharacterDataInterface) !CharacterData {

--- a/source/token.zig
+++ b/source/token.zig
@@ -105,10 +105,7 @@ pub const Token = union(enum) {
         }
     }
 
-    pub fn format(value: Token, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
-
+    pub fn format(value: Token, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         switch (value) {
             .doctype => |d| {
                 try writer.writeAll("DOCTYPE (");

--- a/source/tree_construction.zig
+++ b/source/tree_construction.zig
@@ -6,7 +6,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
-const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const ArrayList = std.ArrayList;
 const StaticStringMap = std.StaticStringMap;
 const StringHashMapUnmanaged = std.StringHashMapUnmanaged;
 
@@ -38,18 +38,18 @@ pub const TreeConstructor = struct {
     insertion_mode: InsertionMode = .Initial,
     original_insertion_mode: InsertionMode = undefined,
 
-    open_elements: ArrayListUnmanaged(*Element) = .{},
-    template_insertion_modes: ArrayListUnmanaged(InsertionMode) = .{},
+    open_elements: ArrayList(*Element) = .empty,
+    template_insertion_modes: ArrayList(InsertionMode) = .empty,
 
-    active_formatting_elements: ArrayListUnmanaged(FormattingElement) = .{},
+    active_formatting_elements: ArrayList(FormattingElement) = .empty,
     // TODO: Somehow make it so that tag attributes do not need to be copied
-    formatting_element_tag_attributes: ArrayListUnmanaged(Token.StartTag.Attributes) = .{},
+    formatting_element_tag_attributes: ArrayList(Token.StartTag.Attributes) = .empty,
     index_of_last_marker: ?usize = null,
 
     head_element_pointer: ?*Element = null,
     form_element_pointer: ?*Element = null,
 
-    pending_table_character_tokens: ArrayListUnmanaged(Token.Character) = .{},
+    pending_table_character_tokens: ArrayList(Token.Character) = .empty,
     pending_table_chars_contains_non_whitespace: bool = false,
 
     parser_cannot_change_the_mode: bool = false,
@@ -3631,7 +3631,7 @@ fn adoptionAgencyAlgorithm(c: *TreeConstructor, element_type: ElementType) !void
         );
         // Step 4.16
         // TODO: This needs to go through the DOM API
-        std.mem.swap(ArrayListUnmanaged(ElementOrCharacterData), &furthest_block.children, &new_element.children);
+        std.mem.swap(ArrayList(ElementOrCharacterData), &furthest_block.children, &new_element.children);
 
         // Step 4.17
         try Dom.mutation.elementAppend(c.dom, furthest_block, .{ .element = new_element }, .Suppress);

--- a/source/util.zig
+++ b/source/util.zig
@@ -6,7 +6,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
-const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const ArrayList = std.ArrayList;
 const StringHashMapUnmanaged = std.StringHashMapUnmanaged;
 
 const rem = @import("../rem.zig");
@@ -120,7 +120,7 @@ pub fn printDocument(writer: anytype, document: *const Document, dom: *const Dom
         element: *const Element,
         cdata: *const CharacterData,
     };
-    var node_stack = ArrayListUnmanaged(struct { node: ConstElementOrCharacterData, depth: usize }){};
+    var node_stack: ArrayList(struct { node: ConstElementOrCharacterData, depth: usize }) = .empty;
     defer node_stack.deinit(allocator);
 
     if (document.element) |document_element| {

--- a/source/util.zig
+++ b/source/util.zig
@@ -105,13 +105,13 @@ pub fn utf8DecodeStringComptime(comptime string: []const u8) [utf8DecodeStringCo
     return result;
 }
 
-pub fn printDocument(writer: anytype, document: *const Document, dom: *const Dom, allocator: Allocator) !void {
-    try std.fmt.format(writer, "Document: {s}\n", .{@tagName(document.quirks_mode)});
+pub fn printDocument(writer: *std.Io.Writer, document: *const Document, dom: *const Dom, allocator: Allocator) !void {
+    try writer.print("Document: {t}\n", .{document.quirks_mode});
 
     try printDocumentCdatas(writer, document, 0);
 
     if (document.doctype) |doctype| {
-        try std.fmt.format(writer, "  DocumentType: name={s} publicId={s} systemId={s}\n", .{ doctype.name, doctype.publicId, doctype.systemId });
+        try writer.print("  DocumentType: name={s} publicId={s} systemId={s}\n", .{ doctype.name, doctype.publicId, doctype.systemId });
     }
 
     try printDocumentCdatas(writer, document, 1);
@@ -131,11 +131,11 @@ pub fn printDocument(writer: anytype, document: *const Document, dom: *const Dom
         const item = node_stack.pop().?;
         var len = item.depth;
         while (len > 0) : (len -= 1) {
-            try std.fmt.format(writer, "  ", .{});
+            try writer.print("  ", .{});
         }
         switch (item.node) {
             .element => |element| {
-                try std.fmt.format(writer, "Element: type={s} local_name={s} namespace={s} attributes=[", .{
+                try writer.print("Element: type={s} local_name={s} namespace={s} attributes=[", .{
                     @tagName(element.element_type),
                     element.localName(dom),
                     @tagName(element.namespace()),
@@ -149,13 +149,13 @@ pub fn printDocument(writer: anytype, document: *const Document, dom: *const Dom
                         const key = attribute_slice.items(.key)[i];
                         const value = attribute_slice.items(.value)[i];
                         if (key.prefix == .none) {
-                            try std.fmt.format(writer, "\"{s}\"=\"{s}\" ", .{ key.local_name, value });
+                            try writer.print("\"{s}\"=\"{s}\" ", .{ key.local_name, value });
                         } else {
-                            try std.fmt.format(writer, "\"{s}:{s}\"=\"{s}\" ", .{ @tagName(key.prefix), key.local_name, value });
+                            try writer.print("\"{s}:{s}\"=\"{s}\" ", .{ @tagName(key.prefix), key.local_name, value });
                         }
                     }
                 }
-                try std.fmt.format(writer, "]\n", .{});
+                try writer.print("]\n", .{});
 
                 // Add children to stack
                 var num_children = element.children.items.len;
@@ -174,17 +174,17 @@ pub fn printDocument(writer: anytype, document: *const Document, dom: *const Dom
     try printDocumentCdatas(writer, document, 2);
 }
 
-fn printDocumentCdatas(writer: anytype, document: *const Document, endpoint_index: u2) !void {
+fn printDocumentCdatas(writer: *std.Io.Writer, document: *const Document, endpoint_index: u2) !void {
     const endpoint = document.cdata_endpoints[endpoint_index];
     for (endpoint.sliceOf(document.cdata.items)) |cdata| {
         try printCdata(writer, cdata);
     }
 }
 
-fn printCdata(writer: anytype, cdata: *const CharacterData) !void {
+fn printCdata(writer: *std.Io.Writer, cdata: *const CharacterData) !void {
     const interface = switch (cdata.interface) {
         .text => "Text",
         .comment => "Comment",
     };
-    try std.fmt.format(writer, "{s}: \"{}\"\n", .{ interface, std.zig.fmtEscapes(cdata.data.items) });
+    try writer.print("{s}: \"{f}\"\n", .{ interface, std.zig.fmtString(cdata.data.items) });
 }

--- a/test/html5lib-test-tokenizer.zig
+++ b/test/html5lib-test-tokenizer.zig
@@ -413,10 +413,8 @@ const ErrorInfo = struct {
         };
     }
 
-    pub fn format(value: @This(), comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
-        try std.fmt.format(writer, "{s}", .{value.id});
+    pub fn format(value: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print("s", .{value.id});
     }
 };
 

--- a/test/html5lib-test-tree-construction.zig
+++ b/test/html5lib-test-tree-construction.zig
@@ -314,8 +314,11 @@ fn createTest(test_string: *[]const u8, allocator: Allocator) !Test {
         error.DomException => unreachable,
         else => |e| return e,
     };
-    // var stderr = std.io.getStdErr().writer();
+    // var buffer: [1024]u8 = undefined;
+    // var stderr_writer = std.fs.File.stderr().writer(&buffer);
+    // const stderr = &stderr_writer.interface;
     // rem.util.printDocument(stderr, expected.document, &expected.dom, allocator) catch panic("", .{});
+    // try stdout.flush();
 
     return Test{
         .input = data,


### PR DESCRIPTION
This PR updates the codebase for Zig 0.15.1.

- Adjust `std.ArrayList` usage to match Zig v0.15.x (unmanaged by default)
- Use `std.ArrayList` instead of deprecated `std.ArrayListUnmanaged`
- Update code to the new `std.Io.Writer` API.

(release notes of Zig v0.15.1: https://ziglang.org/download/0.15.1/release-notes.html)
